### PR TITLE
removed unnecessary ExtendedCompositions

### DIFF
--- a/src/pd_extractor/pd_transform_mappings.py
+++ b/src/pd_extractor/pd_transform_mappings.py
@@ -228,6 +228,8 @@ class TransformMappings(ObjectTransformer):
                 dict_attributes=dict_attributes,
             )
             composition_item["Order"] = i
+            if "c:ExtendedCompositions" in composition_item:
+             composition_item.pop("c:ExtendedCompositions")
             lst_composition_items[i] = composition_item
 
         mapping["Compositions"] = lst_composition_items


### PR DESCRIPTION
fix aliases join conditions

## Summary by Sourcery

Remove the "ExtendedCompositions" field from composition items and fix alias handling in join conditions.

Bug Fixes:
- Fixed an issue with incorrect aliases in join conditions.

Enhancements:
- Removed the unnecessary "ExtendedCompositions" field from the composition data.